### PR TITLE
Upgrade to 2.8.4

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ DOCKER_TAG = docker-push.ocf.berkeley.edu/mastodon:$(DOCKER_REVISION)
 
 .PHONY: cook-image
 cook-image:
-	git clone https://github.com/tootsuite/mastodon -b v2.8.0 --depth 1 src
+	git clone https://github.com/tootsuite/mastodon -b v2.8.4 --depth 1 src
 	cd src; git apply ../patches/*; \
 	docker build --build-arg 'UID=1055' --build-arg 'GID=1055' --pull -t $(DOCKER_TAG) .
 	rm -rf src


### PR DESCRIPTION
Looking through the [upgrade notes](https://github.com/tootsuite/mastodon/releases) this seems like it should be safe, but @fydai please let me know if we're missing anything.