### PR TITLE
Upgrade to 2.9.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ DOCKER_TAG = docker-push.ocf.berkeley.edu/mastodon:$(DOCKER_REVISION)
 
 .PHONY: cook-image
 cook-image:
-	git clone https://github.com/tootsuite/mastodon -b v2.8.4 --depth 1 src
+	git clone https://github.com/tootsuite/mastodon -b v2.9.0 --depth 1 src
 	cd src; git apply ../patches/*; \
 	docker build --build-arg 'UID=1055' --build-arg 'GID=1055' --pull -t $(DOCKER_TAG) .
 	rm -rf src


### PR DESCRIPTION
This version introduces the new default single-column layout.

See the [release notes](https://github.com/tootsuite/mastodon/releases/tag/v2.9.0). This should go smoothly now that #6 is merged, but I'll keep an eye on this upgrade once it ends up happening. We might have to clear cache.