### PR TITLE
kubernetes: clear cache before starting webui

### DIFF
--- a/kubernetes/mastodon-web.yml.erb
+++ b/kubernetes/mastodon-web.yml.erb
@@ -18,7 +18,14 @@ spec:
       containers:
         - name: web
           image: "docker.ocf.berkeley.edu/mastodon:<%= version %>"
-          command: ["sh", "-c", "RAILS_ENV=production bundle exec rails db:migrate; bundle exec rails s -p 3000 -b 0.0.0.0"]
+          command:
+            - sh
+            - -c
+            - >-
+              RAILS_ENV=production
+              bundle exec rails db:migrate;
+              bin/tootctl cache clear;
+              bundle exec rails s -p 3000 -b 0.0.0.0
           ports:
             - name: web
               containerPort: 3000


### PR DESCRIPTION
Usually upgrading Mastodon means we need to clear cache, so this will handle it automatically (just like db migrations).