### PR TITLE
bump mastodon version to 3.1.2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ DOCKER_TAG = docker-push.ocf.berkeley.edu/mastodon:$(DOCKER_REVISION)
 .PHONY: cook-image
 cook-image:
 	git clone https://github.com/tootsuite/mastodon -b v3.1.2 --depth 1 src
-	cd src; git apply ../patches/*; \
+	cd src && git apply ../patches/* && \
 	docker build --build-arg 'UID=1055' --build-arg 'GID=1055' --pull -t $(DOCKER_TAG) .
 	rm -rf src
 

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ DOCKER_TAG = docker-push.ocf.berkeley.edu/mastodon:$(DOCKER_REVISION)
 
 .PHONY: cook-image
 cook-image:
-	git clone https://github.com/tootsuite/mastodon -b v3.1.1 --depth 1 src
+	git clone https://github.com/tootsuite/mastodon -b v3.1.2 --depth 1 src
 	cd src; git apply ../patches/*; \
 	docker build --build-arg 'UID=1055' --build-arg 'GID=1055' --pull -t $(DOCKER_TAG) .
 	rm -rf src

--- a/README.md
+++ b/README.md
@@ -3,3 +3,28 @@
 [![Build Status](https://jenkins.ocf.berkeley.edu/buildStatus/icon?job=mastodon/master)](https://jenkins.ocf.berkeley.edu/job/mastodon/job/master/)
 
 Avaliable at <https://mastodon.ocf.berkeley.edu>.
+
+
+## Updating to new version of Mastodon
+
+Mastodon tracks releases on their [GitHub Releases
+page](https://github.com/tootsuite/mastodon/releases). When there is a new
+release, we upgrade by doing the following.
+
+1. Bump the version tag of the Mastodon repository that is checked out in the
+   Makefile.
+
+2. Update the patchset. To do this:
+   - Clone the mastodon repository to some subdirectory.
+   - Check out the release tag.
+   - Run `git am ../patches/*` to apply the current patches as commits.
+   - Resolve any conflicts, if they occur.
+   - At this point, `git log` should show the tagged commit and then one commit
+     for each patch.
+   - Run `git format-patch <tag> -o ../patches`, where `<tag>` is the release
+     tag, to write out the commits since `<tag>` as patch files.
+
+3. Roll out the changes. Don't forget to follow any instructions specified on
+   the releases page. If you need to run any commands (e.g. database migrations
+   or other jobs), it's usualy easiest to just exec into a container running in
+   Kubernetes.

--- a/patches/0001-indicate-that-OCF-email-is-required.patch
+++ b/patches/0001-indicate-that-OCF-email-is-required.patch
@@ -1,7 +1,7 @@
 From e316a68f78837bcf8c4a64180aa481f1f34d9203 Mon Sep 17 00:00:00 2001
 From: Christopher Cooper <cooperc@ocf.berkeley.edu>
 Date: Thu, 11 Apr 2019 23:07:48 -0700
-Subject: [PATCH 1/2] indicate that OCF email is required
+Subject: [PATCH 1/3] indicate that OCF email is required
 
 ---
  config/locales/en.yml | 2 +-

--- a/patches/0001-indicate-that-OCF-email-is-required.patch
+++ b/patches/0001-indicate-that-OCF-email-is-required.patch
@@ -1,4 +1,4 @@
-From ff7048cee3afe0f79448f0c959baa1b12c0665cc Mon Sep 17 00:00:00 2001
+From e316a68f78837bcf8c4a64180aa481f1f34d9203 Mon Sep 17 00:00:00 2001
 From: Christopher Cooper <cooperc@ocf.berkeley.edu>
 Date: Thu, 11 Apr 2019 23:07:48 -0700
 Subject: [PATCH 1/2] indicate that OCF email is required
@@ -8,10 +8,10 @@ Subject: [PATCH 1/2] indicate that OCF email is required
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/config/locales/en.yml b/config/locales/en.yml
-index 405b0eda5..f7f60bbf7 100644
+index 1d25801..74273b1 100644
 --- a/config/locales/en.yml
 +++ b/config/locales/en.yml
-@@ -1067,7 +1067,7 @@ en:
+@@ -1254,7 +1254,7 @@ en:
        title: Welcome aboard, %{name}!
    users:
      follow_limit_reached: You cannot follow more than %{limit} people
@@ -21,5 +21,5 @@ index 405b0eda5..f7f60bbf7 100644
      otp_lost_help_html: If you lost access to both, you may get in touch with %{email}
      seamless_external_login: You are logged in via an external service, so password and e-mail settings are not available.
 -- 
-2.21.0
+2.11.0
 

--- a/patches/0002-validate-that-Mastodon-username-matches-OCF-username.patch
+++ b/patches/0002-validate-that-Mastodon-username-matches-OCF-username.patch
@@ -1,4 +1,4 @@
-From 4a57be8617b3b7d6438b8ce321c8b7020959f1a0 Mon Sep 17 00:00:00 2001
+From 87e93d0a68c1c746b983cddeec49313f70636b68 Mon Sep 17 00:00:00 2001
 From: Christopher Cooper <cooperc@ocf.berkeley.edu>
 Date: Thu, 11 Apr 2019 23:08:09 -0700
 Subject: [PATCH 2/2] validate that Mastodon username matches OCF username
@@ -10,12 +10,12 @@ Subject: [PATCH 2/2] validate that Mastodon username matches OCF username
  create mode 100644 app/validators/ocf_username_validator.rb
 
 diff --git a/app/models/account.rb b/app/models/account.rb
-index 51e01246e..ca8b6ff17 100644
+index 0eb719d..4a35aa7 100644
 --- a/app/models/account.rb
 +++ b/app/models/account.rb
-@@ -77,6 +77,7 @@ class Account < ApplicationRecord
+@@ -81,6 +81,7 @@ class Account < ApplicationRecord
    validates :display_name, length: { maximum: 30 }, if: -> { local? && will_save_change_to_display_name? }
-   validates :note, note_length: { maximum: 160 }, if: -> { local? && will_save_change_to_note? }
+   validates :note, note_length: { maximum: 500 }, if: -> { local? && will_save_change_to_note? }
    validates :fields, length: { maximum: 4 }, if: -> { local? && will_save_change_to_fields? }
 +  validates_with OCFUsernameValidator, if: -> { local? && will_save_change_to_username? }
  
@@ -23,7 +23,7 @@ index 51e01246e..ca8b6ff17 100644
    scope :local, -> { where(domain: nil) }
 diff --git a/app/validators/ocf_username_validator.rb b/app/validators/ocf_username_validator.rb
 new file mode 100644
-index 000000000..f0ec89c0c
+index 0000000..f0ec89c
 --- /dev/null
 +++ b/app/validators/ocf_username_validator.rb
 @@ -0,0 +1,10 @@
@@ -38,5 +38,5 @@ index 000000000..f0ec89c0c
 +  end
 +end
 -- 
-2.21.0
+2.11.0
 

--- a/patches/0002-validate-that-Mastodon-username-matches-OCF-username.patch
+++ b/patches/0002-validate-that-Mastodon-username-matches-OCF-username.patch
@@ -1,7 +1,7 @@
 From 87e93d0a68c1c746b983cddeec49313f70636b68 Mon Sep 17 00:00:00 2001
 From: Christopher Cooper <cooperc@ocf.berkeley.edu>
 Date: Thu, 11 Apr 2019 23:08:09 -0700
-Subject: [PATCH 2/2] validate that Mastodon username matches OCF username
+Subject: [PATCH 2/3] validate that Mastodon username matches OCF username
 
 ---
  app/models/account.rb                    |  1 +

--- a/patches/0003-Bump-sidekiq-unique-jobs-from-6.0.18-to-6.0.20-13294.patch
+++ b/patches/0003-Bump-sidekiq-unique-jobs-from-6.0.18-to-6.0.20-13294.patch
@@ -1,0 +1,25 @@
+From 0a7c1c312532edbd44687c1a60ea31b64ef06573 Mon Sep 17 00:00:00 2001
+From: Yamagishi Kazutoshi <ykzts@desire.sh>
+Date: Sun, 22 Mar 2020 23:25:23 +0900
+Subject: [PATCH 3/3] Bump sidekiq-unique-jobs from 6.0.18 to 6.0.20 (#13294)
+
+---
+ Gemfile.lock | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/Gemfile.lock b/Gemfile.lock
+index 788785e..5a85ded 100644
+--- a/Gemfile.lock
++++ b/Gemfile.lock
+@@ -574,7 +574,7 @@ GEM
+       rufus-scheduler (~> 3.2)
+       sidekiq (>= 3)
+       tilt (>= 1.4.0)
+-    sidekiq-unique-jobs (6.0.18)
++    sidekiq-unique-jobs (6.0.20)
+       concurrent-ruby (~> 1.0, >= 1.0.5)
+       sidekiq (>= 4.0, < 7.0)
+       thor (~> 0)
+-- 
+2.11.0
+


### PR DESCRIPTION
This requires adding a patch for a current bug in Mastodon (a ruby gem was yanked from the repo). It also adds some better failsafes/documentation around the patch process.